### PR TITLE
Adjust .desktop file to spec

### DIFF
--- a/slimbookrgbkeyboard.desktop
+++ b/slimbookrgbkeyboard.desktop
@@ -1,13 +1,12 @@
 [Desktop Entry]
 Name=Slimbook RGB Keyboard
-Version=0.3.7beta
+Version=1.5
 Exec=slimbookrgbkeyboard
 Comment=Modify your keyboard options!
 Icon=/usr/share/slimbookrgbkeyboard/src/images/icono.png
 Type=Application
 Terminal=false
 StartupNotify=true
-Encoding=UTF-8
 Categories=Utility;
 
 


### PR DESCRIPTION
Using desktop-file-validate on the .desktop file returns the following erros:
```
slimbookrgbkeyboard.desktop: error: value "0.3.7beta" for key "Version" in group "Desktop Entry" is not a known version
slimbookrgbkeyboard.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
```
The first is regarding the fact that the version field is regarding the Desktop Entry Specification, last version being 1.5, not the app version. See https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html

The second is just deprecated and removed.