### PR TITLE
Fix getting user from subprocess

### DIFF
--- a/src/configuration/utils.py
+++ b/src/configuration/utils.py
@@ -20,7 +20,7 @@ def get_user(from_file=None):
         if 'SUDO_USER' in os.environ and os.environ['SUDO_USER'] != 'root':
             user_name = os.environ['SUDO_USER']
         else:
-            user_name = subprocess.getoutput('last -wn1 | head -n 1 | cut -f 1 -d " "')
+            user_name = subprocess.getoutput('w -h | head -n 1 | cut -f 1 -d " "')
 
     return user_name
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -18,14 +18,14 @@ def get_user(from_file=None):
         try:
             user_name = os.getlogin()
         except:
-            user_name = subprocess.getoutput('last -wn1 | head -n 1 | cut -f 1 -d " "')
+            user_name = subprocess.getoutput('w -h | head -n 1 | cut -f 1 -d " "')
     
 
     if user_name == 'root':
         if 'SUDO_USER' in os.environ and os.environ['SUDO_USER'] != 'root':
             user_name = os.environ['SUDO_USER']
         else:
-            user_name = subprocess.getoutput('last -wn1 | head -n 1 | cut -f 1 -d " "')
+            user_name = subprocess.getoutput('w -h | head -n 1 | cut -f 1 -d " "')
 
     return user_name
 


### PR DESCRIPTION
`last` command seems to not get included in several distros these days (eg. Debian/Ubuntu/Fedora)
Change to `w` as that seems to be still installed by default 